### PR TITLE
feat(gpu): ROCm/HIP backend for AMD GPU inference via Panama FFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.releaseBackup
 release.properties
 dist/
 .release-gpg/
+models/
+*.gguf

--- a/juno-player/src/main/java/cab/ml/juno/player/ConsoleMain.java
+++ b/juno-player/src/main/java/cab/ml/juno/player/ConsoleMain.java
@@ -47,6 +47,7 @@ import cab.ml.juno.kvcache.GpuKVCache;
 import cab.ml.juno.kvcache.KVCacheManager;
 import cab.ml.juno.node.ActivationDtype;
 import cab.ml.juno.node.CudaAvailability;
+import cab.ml.juno.node.RocmAvailability;
 import cab.ml.juno.node.ForwardPassHandler;
 import cab.ml.juno.node.CudaMatVec;
 import cab.ml.juno.node.MatVec;
@@ -1212,10 +1213,13 @@ public final class ConsoleMain {
 	}
 
 	private static GpuContext prepareGpuContext() {
-		if (!useGpu || !CudaAvailability.isAvailable())
+		boolean gpuAvailable = CudaAvailability.isAvailable() || RocmAvailability.isAvailable();
+		if (!useGpu || !gpuAvailable)
 			return null;
 		int dev = Math.max(0, Integer.getInteger("juno.cuda.device", 0));
-		if (dev >= CudaAvailability.deviceCount()) {
+		int devCount = CudaAvailability.isAvailable()
+			? CudaAvailability.deviceCount() : RocmAvailability.deviceCount();
+		if (dev >= devCount) {
 			log.warning("juno.cuda.device=" + dev + " out of range — using CPU matmul for local REPL");
 			return null;
 		}

--- a/juno-player/src/main/java/cab/ml/juno/player/JunoPlayer.java
+++ b/juno-player/src/main/java/cab/ml/juno/player/JunoPlayer.java
@@ -37,6 +37,7 @@ import cab.ml.juno.kvcache.GpuKVCache;
 import cab.ml.juno.kvcache.KVCacheManager;
 import cab.ml.juno.lora.LoraAdapterSet;
 import cab.ml.juno.node.CudaAvailability;
+import cab.ml.juno.node.RocmAvailability;
 import cab.ml.juno.node.CudaMatVec;
 import cab.ml.juno.node.ForwardPassHandler;
 import cab.ml.juno.node.ForwardPassHandlerLoader;
@@ -264,10 +265,13 @@ public final class JunoPlayer implements AutoCloseable {
 		}
 
 		private static GpuContext prepareGpuContext(boolean useGpu) {
-			if (!useGpu || !CudaAvailability.isAvailable())
+			boolean gpuAvailable = CudaAvailability.isAvailable() || RocmAvailability.isAvailable();
+			if (!useGpu || !gpuAvailable)
 				return null;
 			int dev = Math.max(0, Integer.getInteger("juno.cuda.device", 0));
-			if (dev >= CudaAvailability.deviceCount())
+			int devCount = CudaAvailability.isAvailable()
+				? CudaAvailability.deviceCount() : RocmAvailability.deviceCount();
+			if (dev >= devCount)
 				return null;
 			return GpuContext.shared(dev);
 		}

--- a/node/src/main/java/cab/ml/juno/node/CpuMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/CpuMatVec.java
@@ -45,7 +45,7 @@ public final class CpuMatVec implements MatVec {
 		MatVecEvent evt = new MatVecEvent();
 		evt.begin();
 		float[] result = LlamaTransformerHandler.matVec(A, x, rows, cols);
-		evt.backend = "cpu";
+		evt.backend(MatVecBackend.CPU);
 		evt.rows = rows;
 		evt.cols = cols;
 		evt.commit();

--- a/node/src/main/java/cab/ml/juno/node/CudaAvailability.java
+++ b/node/src/main/java/cab/ml/juno/node/CudaAvailability.java
@@ -33,9 +33,10 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
  * cudaDeviceProp struct via a confined arena, read the fields, then release
  * immediately — zero heap allocation during the read.
  *
- * Struct field offsets are read from {@link GpuBindings#PROP_NAME_OFFSET} and
- * {@link GpuBindings#PROP_TOTAL_MEM_OFFSET} so they stay in sync with
- * {@link CudaBindings}.
+ * Struct field offsets ({@link CudaBindings#PROP_NAME_OFFSET},
+ * {@link CudaBindings#PROP_TOTAL_MEM_OFFSET}) are CUDA 12.x / Linux x86_64.
+ * Both are also accessible via {@link GpuBindings#propNameOffset()} and
+ * {@link GpuBindings#propTotalMemOffset()} for vendor-neutral callers.
  */
 public final class CudaAvailability {
 

--- a/node/src/main/java/cab/ml/juno/node/CudaMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/CudaMatVec.java
@@ -172,7 +172,7 @@ public final class CudaMatVec implements GpuMatVec {
             cuda.deviceFree(dA);
             cuda.deviceFree(dX);
             cuda.deviceFree(dY);
-            evt.backend = "cuda";
+            evt.backend(MatVecBackend.CUDA);
             evt.rows = rows;
             evt.cols = cols;
             evt.commit();
@@ -235,7 +235,7 @@ public final class CudaMatVec implements GpuMatVec {
                 }
             }
         } finally {
-            evt.backend = "cuda-resident";
+            evt.backend(MatVecBackend.CUDA_RESIDENT);
             evt.rows = rows;
             evt.cols = cols;
             evt.commit();
@@ -301,7 +301,7 @@ public final class CudaMatVec implements GpuMatVec {
                 }
             }
         } finally {
-            evt.backend = "cuda-resident-fp16";
+            evt.backend(MatVecBackend.CUDA_RESIDENT_FP16);
             evt.rows = rows;
             evt.cols = cols;
             evt.commit();

--- a/node/src/main/java/cab/ml/juno/node/CudaMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/CudaMatVec.java
@@ -58,7 +58,7 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
  *
  * @author Yevhen Soldatov
  */
-public final class CudaMatVec implements MatVec {
+public final class CudaMatVec implements GpuMatVec {
 
     @SuppressWarnings("unused")
     private static final Logger log = Logger.getLogger(CudaMatVec.class.getName());
@@ -111,11 +111,13 @@ public final class CudaMatVec implements MatVec {
 
     // ── Upload helpers (for LlamaTransformerHandler / LoraTrainableHandler) ──
 
-    DeviceFloatMatrix upload(float[] host, int rows, int cols) {
+    @Override
+    public DeviceFloatMatrix upload(float[] host, int rows, int cols) {
         return DeviceFloatMatrix.upload(ctx, host, rows, cols);
     }
 
-    DeviceHalfMatrix uploadHalf(float[] host, int rows, int cols) {
+    @Override
+    public DeviceHalfMatrix uploadHalf(float[] host, int rows, int cols) {
         return DeviceHalfMatrix.uploadFromFloat32(ctx, host, rows, cols);
     }
 

--- a/node/src/main/java/cab/ml/juno/node/DeviceFloatMatrix.java
+++ b/node/src/main/java/cab/ml/juno/node/DeviceFloatMatrix.java
@@ -15,6 +15,7 @@
  */
 package cab.ml.juno.node;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
@@ -22,11 +23,15 @@ import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 /**
  * Row-major FP32 weight matrix resident on the GPU.
  *
- * The device memory is allocated once via {@link CudaBindings#deviceMalloc} and
+ * The device memory is allocated once via {@link GpuBindings#deviceMalloc} and
  * freed by {@link #close}. The backing {@link MemorySegment} is sized to
  * {@code rows * cols * 4} bytes so bounds checks work at the Java level.
  *
- * Used with {@link CudaMatVec#sgemv(DeviceFloatMatrix, float[])} so each
+ * Vendor-neutral: all device operations go through the {@link GpuBindings}
+ * obtained from {@link GpuContext#bindings()} (captured at construction), so the
+ * same class serves both CUDA and ROCm backends.
+ *
+ * Used with {@link MatVec#sgemv(DeviceFloatMatrix, float[])} so each
  * matmul skips re-uploading A.
  *
  * @author Yevhen Soldatov
@@ -34,6 +39,7 @@ import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 public final class DeviceFloatMatrix implements AutoCloseable {
 
     private final GpuContext    ctx;
+    private final GpuBindings   gpu;
     /** Device pointer, sized to rows * cols * Float.BYTES. */
     private final MemorySegment dA;
     private final int           rows;
@@ -42,6 +48,7 @@ public final class DeviceFloatMatrix implements AutoCloseable {
 
     private DeviceFloatMatrix(GpuContext ctx, MemorySegment dA, int rows, int cols) {
         this.ctx  = ctx;
+        this.gpu  = ctx.bindings();
         this.dA   = dA;
         this.rows = rows;
         this.cols = cols;
@@ -62,14 +69,19 @@ public final class DeviceFloatMatrix implements AutoCloseable {
             throw new IllegalArgumentException(
                 "host.length=" + host.length + " != rows*cols=" + ((long) rows * cols));
 
-        CudaBindings   cuda  = CudaBindings.instance();
+        GpuBindings    gpu   = ctx.bindings();
         long           bytes = (long) rows * cols * Float.BYTES;
-        MemorySegment  dA    = cuda.deviceMalloc(ctx.deviceIndex(), bytes);
+        MemorySegment  dA    = gpu.deviceMalloc(ctx.deviceIndex(), bytes);
 
-        // MemorySegment.ofArray pins the heap array for the duration of the downcall.
-        CudaBindings.check(
-            CudaBindings.callInt(cuda.cudaMemcpy, dA, MemorySegment.ofArray(host), bytes, CudaBindings.H2D),
-            "cudaMemcpy(A H2D)");
+        // Stage the heap array into an off-heap (native) buffer first; Java 25
+        // Panama forbids passing heap-backed MemorySegments to native downcalls.
+        try (Arena staging = Arena.ofConfined()) {
+            MemorySegment nativeHost = staging.allocate(bytes);
+            nativeHost.copyFrom(MemorySegment.ofArray(host));
+            GpuBindings.check(
+                GpuBindings.callInt(gpu.cudaMemcpy(), dA, nativeHost, bytes, GpuBindings.H2D),
+                "memcpy(A H2D)");
+        }
 
         return new DeviceFloatMatrix(ctx, dA, rows, cols);
     }
@@ -92,8 +104,8 @@ public final class DeviceFloatMatrix implements AutoCloseable {
     public void close() {
         if (!closed) {
             closed = true;
-            CudaBindings.callInt(CudaBindings.instance().cudaSetDevice, ctx.deviceIndex());
-            CudaBindings.instance().deviceFree(dA);
+            GpuBindings.callInt(gpu.cudaSetDevice(), ctx.deviceIndex());
+            gpu.deviceFree(dA);
         }
     }
 }

--- a/node/src/main/java/cab/ml/juno/node/DeviceHalfMatrix.java
+++ b/node/src/main/java/cab/ml/juno/node/DeviceHalfMatrix.java
@@ -31,12 +31,17 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
  * before upload, avoiding any GC-visible byte array allocation for the staging
  * buffer. The H2D transfer uses synchronous {@code cudaMemcpy}.
  *
- * Used with {@link CudaMatVec#sgemv(DeviceHalfMatrix, float[])} (mixed
- * FP16/FP32 cuBLAS path) so activations stay float32 while weights stay compact.
+ * Used with {@link MatVec#sgemv(DeviceHalfMatrix, float[])} (mixed
+ * FP16/FP32 BLAS path) so activations stay float32 while weights stay compact.
+ *
+ * Vendor-neutral: device operations go through the {@link GpuBindings} obtained
+ * from {@link GpuContext#bindings()} (captured at construction), so the same
+ * class serves both CUDA and ROCm backends.
  */
 public final class DeviceHalfMatrix implements AutoCloseable {
 
     private final GpuContext    ctx;
+    private final GpuBindings   gpu;
     /** Device pointer, sized to rows * cols * Short.BYTES. */
     private final MemorySegment dA;
     private final int           rows;
@@ -45,6 +50,7 @@ public final class DeviceHalfMatrix implements AutoCloseable {
 
     private DeviceHalfMatrix(GpuContext ctx, MemorySegment dA, int rows, int cols) {
         this.ctx  = ctx;
+        this.gpu  = ctx.bindings();
         this.dA   = dA;
         this.rows = rows;
         this.cols = cols;
@@ -64,21 +70,21 @@ public final class DeviceHalfMatrix implements AutoCloseable {
             throw new IllegalArgumentException(
                 "host.length=" + host.length + " != rows*cols=" + ((long) rows * cols));
 
-        CudaBindings  cuda      = CudaBindings.instance();
+        GpuBindings   gpu       = ctx.bindings();
         int           n         = rows * cols;
         long          halfBytes = (long) n * Short.BYTES;
-        MemorySegment dA        = cuda.deviceMalloc(ctx.deviceIndex(), halfBytes);
+        MemorySegment dA        = gpu.deviceMalloc(ctx.deviceIndex(), halfBytes);
 
         // Pack float32 → FP16 into off-heap staging; JAVA_SHORT has native byte order
-        // (little-endian on x86), matching CUDA's __half memory layout.
+        // (little-endian on x86), matching CUDA's __half / HIP's __half memory layout.
         try (Arena staging = Arena.ofConfined()) {
             MemorySegment stagingHost = staging.allocate(halfBytes);
             for (int i = 0; i < n; i++)
                 stagingHost.setAtIndex(JAVA_SHORT, i, Float.floatToFloat16(host[i]));
 
-            CudaBindings.check(
-                CudaBindings.callInt(cuda.cudaMemcpy, dA, stagingHost, halfBytes, CudaBindings.H2D),
-                "cudaMemcpy(A FP16 H2D)");
+            GpuBindings.check(
+                GpuBindings.callInt(gpu.cudaMemcpy(), dA, stagingHost, halfBytes, GpuBindings.H2D),
+                "memcpy(A FP16 H2D)");
         }
 
         return new DeviceHalfMatrix(ctx, dA, rows, cols);
@@ -102,8 +108,8 @@ public final class DeviceHalfMatrix implements AutoCloseable {
     public void close() {
         if (!closed) {
             closed = true;
-            CudaBindings.callInt(CudaBindings.instance().cudaSetDevice, ctx.deviceIndex());
-            CudaBindings.instance().deviceFree(dA);
+            GpuBindings.callInt(gpu.cudaSetDevice(), ctx.deviceIndex());
+            gpu.deviceFree(dA);
         }
     }
 }

--- a/node/src/main/java/cab/ml/juno/node/ForwardPassHandlerLoader.java
+++ b/node/src/main/java/cab/ml/juno/node/ForwardPassHandlerLoader.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 
 import cab.ml.juno.lora.LoraAdapterSet;
+import cab.ml.juno.node.RocmAvailability;
 
 
 /**
@@ -105,16 +106,18 @@ public final class ForwardPassHandlerLoader {
 	}
 
 	private static MatVec pickMatVec(boolean useGpu) {
-		if (useGpu && CudaAvailability.isAvailable()) {
+		boolean gpuAvailable = CudaAvailability.isAvailable() || RocmAvailability.isAvailable();
+		if (useGpu && gpuAvailable) {
 			int dev = Math.max(0, Integer.getInteger("juno.cuda.device", 0));
-			if (dev >= CudaAvailability.deviceCount()) {
+			int devCount = CudaAvailability.isAvailable()
+				? CudaAvailability.deviceCount() : RocmAvailability.deviceCount();
+			if (dev >= devCount) {
 				log.warning("juno.cuda.device=" + dev + " out of range — using CpuMatVec");
 				return CpuMatVec.INSTANCE;
 			}
-			log.info("CUDA detected — using CudaMatVec backend (device " + dev + ")");
 			return GpuContext.shared(dev).createMatVec();
 		}
-		log.info("Using CpuMatVec backend (useGpu=" + useGpu + ", CUDA=" + CudaAvailability.isAvailable() + ")");
+		log.info("Using CpuMatVec backend (useGpu=" + useGpu + ", gpuAvailable=" + gpuAvailable + ")");
 		return CpuMatVec.INSTANCE;
 	}
 

--- a/node/src/main/java/cab/ml/juno/node/GpuMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/GpuMatVec.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Dmytro Soloviov (soulaway)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cab.ml.juno.node;
+
+/**
+ * A {@link MatVec} backed by a GPU that can hold weight matrices resident in
+ * device memory.
+ *
+ * <p>Both {@link CudaMatVec} (NVIDIA) and {@link RocmMatVec} (AMD) implement
+ * this interface. Transformer handlers ({@link LlamaTransformerHandler},
+ * {@link Phi3TransformerHandler}, {@link LoraTrainableHandler}) depend on this
+ * abstraction — not on a concrete vendor backend — so the device-resident
+ * upload path is taken on <em>any</em> GPU, not just CUDA.
+ *
+ * <h3>Design — Dependency Inversion / Open–Closed</h3>
+ * Previously the handlers gated GPU weight upload on {@code instanceof
+ * CudaMatVec}, which silently routed AMD nodes onto the CPU path. Depending on
+ * {@code GpuMatVec} instead keeps the handlers closed for modification while
+ * remaining open to additional GPU backends.
+ *
+ * <p>The interface is {@code sealed}: only the in-module GPU backends may
+ * implement it. CPU-only backends ({@link CpuMatVec}) intentionally implement
+ * {@link MatVec} directly and do not expose device-resident uploads.
+ */
+sealed interface GpuMatVec extends MatVec permits CudaMatVec, RocmMatVec {
+
+    /**
+     * Uploads a row-major FP32 weight matrix to device memory, held resident
+     * across subsequent {@link #sgemv(DeviceFloatMatrix, float[])} calls.
+     *
+     * @param host row-major A, length {@code rows * cols}
+     */
+    DeviceFloatMatrix upload(float[] host, int rows, int cols);
+
+    /**
+     * Uploads a row-major weight matrix as FP16 (IEEE binary16) to device
+     * memory, held resident across subsequent
+     * {@link #sgemv(DeviceHalfMatrix, float[])} calls. Activations stay FP32;
+     * the BLAS kernel accumulates in FP32.
+     *
+     * @param host row-major A (FP32 source), length {@code rows * cols}
+     */
+    DeviceHalfMatrix uploadHalf(float[] host, int rows, int cols);
+}

--- a/node/src/main/java/cab/ml/juno/node/LlamaTransformerHandler.java
+++ b/node/src/main/java/cab/ml/juno/node/LlamaTransformerHandler.java
@@ -1060,7 +1060,7 @@ public final class LlamaTransformerHandler implements ForwardPassHandler {
 		evt.begin();
 		try {
 			float[] y = matVecQuantizedNoEvent(A, x, rowStart, rowEnd, cols);
-			evt.backend = matVecQuantBackendLabel(A.type());
+			evt.backend(matVecQuantBackend(A.type()));
 			evt.rows = rowEnd - rowStart;
 			evt.cols = cols;
 			return y;
@@ -1070,20 +1070,20 @@ public final class LlamaTransformerHandler implements ForwardPassHandler {
 	}
 
 	/**
-	 * Returns the JFR backend label for a quantized matVec call.
+	 * Returns the JFR backend for a quantized matVec call.
 	 *
 	 * <p>All quantized overloads (matVecQ4Kraw, matVecQ6Kraw, etc.)
 	 * are pure-Java CPU computations executed on
 	 * ForkJoinPool.commonPool(). They never touch a GPU, so they are labelled
-	 * "cpu" — the same label used by {@link CpuMatVec#sgemv}. This ensures
-	 * juno.MatVec.backend.cpu.count reflects the true number of CPU-side
-	 * matrix multiplies, including quantized ones.
+	 * {@link MatVecBackend#CPU} — the same label used by {@link CpuMatVec#sgemv}.
+	 * This ensures juno.MatVec.backend.cpu.count reflects the true number of
+	 * CPU-side matrix multiplies, including quantized ones.
 	 *
 	 * @param ggmlType GGML type ID (unused — kept for signature clarity)
 	 */
 	@SuppressWarnings("unused")
-	private static String matVecQuantBackendLabel(int ggmlType) {
-		return "cpu";
+	private static MatVecBackend matVecQuantBackend(int ggmlType) {
+		return MatVecBackend.CPU;
 	}
 
 	/** Quantized matVec without JFR (inner implementation for {@link #matVec(GgufReader.QuantizedTensor, float[], int, int, int)}). */

--- a/node/src/main/java/cab/ml/juno/node/LlamaTransformerHandler.java
+++ b/node/src/main/java/cab/ml/juno/node/LlamaTransformerHandler.java
@@ -249,11 +249,11 @@ public final class LlamaTransformerHandler implements ForwardPassHandler {
 		log.info("Shard loaded — " + L + " layers, " + (hasEmbeddings ? "with embeddings, " : "")
 				+ (hasOutputProj ? "with output projection" : "no output projection"));
 
-		// Upload dequantized weights to GPU when a CudaMatVec backend is provided.
+		// Upload dequantized weights to GPU when a GPU backend is provided.
 		wqDev = wkDev = wvDev = woDev = wGateDev = wUpDev = wDownDev = null;
 		outputProjDev = null;
-		if (backend instanceof CudaMatVec cuda) {
-			log.info("Uploading dequantized weights to GPU (FP16 cuda-resident)…");
+		if (backend instanceof GpuMatVec cuda) {
+			log.info("Uploading dequantized weights to GPU (FP16 device-resident)…");
 			int H  = cfg.hiddenDim();
 			int KV = cfg.kvDim();
 			int I  = cfg.intermediateSize();
@@ -298,7 +298,7 @@ public final class LlamaTransformerHandler implements ForwardPassHandler {
 				if (outD != null)
 					outD.close();
 				String msg = ex.getMessage() == null ? "" : ex.getMessage();
-				if (msg.contains("cudaMalloc")) {
+				if (msg.contains("cudaMalloc") || msg.contains("hipMalloc")) {
 					log.warning("Llama: insufficient GPU VRAM for FP16-resident weights (" + msg
 							+ "). Using CPU quantised matmul for projections.");
 				} else {

--- a/node/src/main/java/cab/ml/juno/node/LoraTrainableHandler.java
+++ b/node/src/main/java/cab/ml/juno/node/LoraTrainableHandler.java
@@ -192,7 +192,7 @@ public final class LoraTrainableHandler implements ForwardPassHandler {
 
 		wqDev = wkDev = wvDev = woDev = wGateDev = wUpDev = wDownDev = null;
 		outputProjDev = null;
-		if (backend instanceof CudaMatVec cuda) {
+		if (backend instanceof GpuMatVec cuda) {
 			log.info("LoRA handler: uploading projection weights to GPU (FP16)…");
 			int H = cfg.hiddenDim();
 			int KV = cfg.kvDim();
@@ -238,7 +238,7 @@ public final class LoraTrainableHandler implements ForwardPassHandler {
 				if (outD != null)
 					outD.close();
 				String msg = ex.getMessage() == null ? "" : ex.getMessage();
-				if (msg.contains("cudaMalloc")) {
+				if (msg.contains("cudaMalloc") || msg.contains("hipMalloc")) {
 					log.warning("LoRA: insufficient GPU VRAM for FP16-resident weights (" + msg
 							+ "). Using CPU quantised matmul.");
 				} else {

--- a/node/src/main/java/cab/ml/juno/node/MatVecBackend.java
+++ b/node/src/main/java/cab/ml/juno/node/MatVecBackend.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Dmytro Soloviov (soulaway)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cab.ml.juno.node;
+
+/**
+ * Compute backend reported on each {@link MatVecEvent}. The single source of
+ * truth for the {@code juno.MatVec.backend} JFR dimension — previously every
+ * {@code MatVec} implementation assigned the label as an ad-hoc string literal
+ * ({@code "cuda-resident-fp16"} and friends), which was easy to mistype and
+ * impossible to enumerate.
+ *
+ * <p>The {@link #label()} strings are part of the JFR contract consumed by
+ * tooling (JDK Mission Control, {@code juno.MatVec.backend.*.count}); keep them
+ * stable.
+ *
+ * <p>The GPU vendor variants follow the pattern {@code <vendor>[-resident][-fp16]}:
+ * <ul>
+ *   <li>{@code <vendor>} — full host path (A and x copied per call)</li>
+ *   <li>{@code <vendor>-resident} — A held resident on the device (FP32)</li>
+ *   <li>{@code <vendor>-resident-fp16} — A held resident as FP16</li>
+ * </ul>
+ */
+enum MatVecBackend {
+
+    /** Pure-Java parallel CPU path (also used by all quantized GGUF matVecs). */
+    CPU("cpu"),
+
+    /** cuBLAS {@code cublasSgemv_v2}, A and x copied host→device per call. */
+    CUDA("cuda"),
+    /** cuBLAS {@code cublasSgemv_v2} with device-resident FP32 A. */
+    CUDA_RESIDENT("cuda-resident"),
+    /** cuBLAS {@code cublasHSSgemvStridedBatched} with device-resident FP16 A. */
+    CUDA_RESIDENT_FP16("cuda-resident-fp16"),
+
+    /** rocBLAS {@code rocblas_sgemv}, A and x copied host→device per call. */
+    ROCM("rocm"),
+    /** rocBLAS {@code rocblas_sgemv} with device-resident FP32 A. */
+    ROCM_RESIDENT("rocm-resident"),
+    /** rocBLAS {@code rocblas_hssgemv_strided_batched} with device-resident FP16 A. */
+    ROCM_RESIDENT_FP16("rocm-resident-fp16");
+
+    private final String label;
+
+    MatVecBackend(String label) {
+        this.label = label;
+    }
+
+    /** Stable JFR label, e.g. {@code "rocm-resident-fp16"}. */
+    String label() {
+        return label;
+    }
+}

--- a/node/src/main/java/cab/ml/juno/node/MatVecEvent.java
+++ b/node/src/main/java/cab/ml/juno/node/MatVecEvent.java
@@ -51,9 +51,17 @@ import jdk.jfr.StackTrace;
 public final class MatVecEvent extends Event {
 
     @Label("Backend")
-    @Description("Compute backend: \"cpu\" (parallel IntStream), \"cuda\" (cublasSgemv host A), "
-            + "\"cuda-resident\" (cublasSgemv device A)")
+    @Description("Compute backend label — see MatVecBackend (e.g. \"cpu\", \"cuda\", "
+            + "\"cuda-resident\", \"rocm-resident-fp16\")")
     public String backend;
+
+    /**
+     * Sets the {@link #backend} JFR label from a typed {@link MatVecBackend},
+     * avoiding hand-written label strings at the call sites.
+     */
+    public void backend(MatVecBackend b) {
+        this.backend = b.label();
+    }
 
     @Label("Rows")
     @Description("Number of output elements (output dimension of A)")

--- a/node/src/main/java/cab/ml/juno/node/Phi3TransformerHandler.java
+++ b/node/src/main/java/cab/ml/juno/node/Phi3TransformerHandler.java
@@ -224,7 +224,7 @@ public final class Phi3TransformerHandler implements ForwardPassHandler {
 			logLayerMemory(i, H, kvDim, I, attnQkv[li], wo[li], ffnGateUp[li], wDown[li]);
 		}
 
-		if (backend instanceof CudaMatVec cuda) {
+		if (backend instanceof GpuMatVec cuda) {
 			log.info("Uploading Phi-3 dequantized projection weights to GPU (FP16 storage)…");
 			DeviceHalfMatrix[] qD = new DeviceHalfMatrix[L];
 			DeviceHalfMatrix[] kD = new DeviceHalfMatrix[L];
@@ -269,7 +269,7 @@ public final class Phi3TransformerHandler implements ForwardPassHandler {
 				closeDeviceHalfMatrixArray(dD);
 				if (outD != null)
 					outD.close();
-				if (ex.getMessage() != null && ex.getMessage().contains("cudaMalloc")) {
+				if (ex.getMessage() != null && (ex.getMessage().contains("cudaMalloc") || ex.getMessage().contains("hipMalloc"))) {
 					log.warning(
 							"Phi-3: not enough GPU VRAM for FP16-resident weights on this shard (" + ex.getMessage()
 									+ "). Using CPU quantised matmul. "

--- a/node/src/main/java/cab/ml/juno/node/RocmMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/RocmMatVec.java
@@ -179,7 +179,7 @@ public final class RocmMatVec implements GpuMatVec {
             rocm.deviceFree(dA);
             rocm.deviceFree(dX);
             rocm.deviceFree(dY);
-            evt.backend = "rocm";
+            evt.backend(MatVecBackend.ROCM);
             evt.rows = rows;
             evt.cols = cols;
             evt.commit();
@@ -244,7 +244,7 @@ public final class RocmMatVec implements GpuMatVec {
                 }
             }
         } finally {
-            evt.backend = "rocm-resident";
+            evt.backend(MatVecBackend.ROCM_RESIDENT);
             evt.rows = rows;
             evt.cols = cols;
             evt.commit();
@@ -311,7 +311,7 @@ public final class RocmMatVec implements GpuMatVec {
                 }
             }
         } finally {
-            evt.backend = "rocm-resident-fp16";
+            evt.backend(MatVecBackend.ROCM_RESIDENT_FP16);
             evt.rows = rows;
             evt.cols = cols;
             evt.commit();

--- a/node/src/main/java/cab/ml/juno/node/RocmMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/RocmMatVec.java
@@ -36,12 +36,12 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
  * performs synchronous D2H copy of y; frees the temporary buffers.
  *
  * <p>Device-resident paths ({@link DeviceFloatMatrix}, {@link DeviceHalfMatrix})
- * are not yet supported — those classes internally call {@link CudaBindings} for
- * memory management. Use the host-weight path ({@code sgemv(float[], float[], int, int)})
- * or contribute {@code RocmDeviceFloatMatrix} / {@code RocmDeviceHalfMatrix} analogues.
+ * keep A on the GPU across calls; only x and y cross the bus per matmul. The
+ * device matrices allocate through the vendor-neutral {@link GpuBindings} from
+ * {@link GpuContext#bindings()}, so they work identically on AMD and NVIDIA.
  *
- * <p>Per-thread HIP streams are used for the resident-A async path (same
- * pattern as {@link CudaMatVec}). The serialization lock from
+ * <p>Per-thread HIP streams back the resident async path (same pattern as
+ * {@link CudaMatVec}). The serialization lock from
  * {@link GpuContext#cublasSerializationLock()} guards rocBLAS handle usage.
  *
  * <p>Requires JVM flag: {@code --enable-native-access=ALL-UNNAMED}.
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
  * @see GpuContext#createMatVec()
  * @see RocmBindings
  */
-public final class RocmMatVec implements MatVec {
+public final class RocmMatVec implements GpuMatVec {
 
     @SuppressWarnings("unused")
     private static final Logger log = Logger.getLogger(RocmMatVec.class.getName());
@@ -60,20 +60,31 @@ public final class RocmMatVec implements MatVec {
     private final RocmBindings rocm;
 
     // ── Per-thread device scratch ─────────────────────────────────────────────
-    private static final ThreadLocal<Scratch> SCRATCH =
-        ThreadLocal.withInitial(Scratch::new);
+    // ── Per-thread device scratch (FP32 resident path) ────────────────────
+    private static final ThreadLocal<Fp32Scratch> FP32_SCRATCH =
+        ThreadLocal.withInitial(Fp32Scratch::new);
 
-    // ── Per-thread HIP stream ─────────────────────────────────────────────────
+    // ── Per-thread device scratch (FP16 resident path) ────────────────────
+    private static final ThreadLocal<Fp16Scratch> FP16_SCRATCH =
+        ThreadLocal.withInitial(Fp16Scratch::new);
+
+    // ── Per-thread HIP stream ───────────────────────────────────
     private static final ThreadLocal<MemorySegment> HIP_STREAM =
         ThreadLocal.withInitial(() -> null);
 
-    private static final class Scratch {
+    private static final class Fp32Scratch {
         MemorySegment dX;
         MemorySegment dY;
         long dXBytes;
         long dYBytes;
     }
 
+    private static final class Fp16Scratch {
+        MemorySegment dXh;  // device FP16 x, grown as needed
+        MemorySegment dY;   // device FP32 y, grown as needed
+        long dXhBytes;
+        long dYBytes;
+    }
     // ── Construction ──────────────────────────────────────────────────────────
 
     /**
@@ -93,6 +104,18 @@ public final class RocmMatVec implements MatVec {
     }
 
     GpuContext gpuContext() { return ctx; }
+
+    // ── Upload helpers (for transformer handlers) ───────────────────────
+
+    @Override
+    public DeviceFloatMatrix upload(float[] host, int rows, int cols) {
+        return DeviceFloatMatrix.upload(ctx, host, rows, cols);
+    }
+
+    @Override
+    public DeviceHalfMatrix uploadHalf(float[] host, int rows, int cols) {
+        return DeviceHalfMatrix.uploadFromFloat32(ctx, host, rows, cols);
+    }
 
     // ── MatVec ────────────────────────────────────────────────────────────────
 
@@ -164,32 +187,135 @@ public final class RocmMatVec implements MatVec {
     }
 
     /**
-     * Device-resident FP32 path — not yet supported on ROCm.
+     * Device-resident FP32 path: A stays on the device across calls.
      *
-     * {@link DeviceFloatMatrix} allocates memory via {@link CudaBindings} internally.
-     * Contribute {@code RocmDeviceFloatMatrix} to enable this path on AMD GPUs.
-     *
-     * @throws UnsupportedOperationException always
+     * Per-thread scratch buffers for x and y are grown lazily and reused. The
+     * D2H copy uses a confined off-heap arena so the async HIP stream never
+     * targets a GC-moveable heap address. Mirrors
+     * {@link CudaMatVec#sgemv(DeviceFloatMatrix, float[])}.
      */
     @Override
     public float[] sgemv(DeviceFloatMatrix A, float[] x) {
-        throw new UnsupportedOperationException(
-            "RocmMatVec: device-resident FP32 path not yet supported. " +
-            "DeviceFloatMatrix uses CudaBindings internally. " +
-            "See GpuContext.createMatVec() javadoc for the host-weight workaround.");
+        if (A == null) throw new IllegalArgumentException("A must not be null");
+        if (A.isClosed()) throw new IllegalStateException("DeviceFloatMatrix is closed");
+        int rows = A.rows(), cols = A.cols();
+        if (x.length != cols)
+            throw new IllegalArgumentException("x.length=" + x.length + " != cols=" + cols);
+
+        MatVecEvent evt = new MatVecEvent();
+        evt.begin();
+
+        long bytesX = (long) cols * Float.BYTES;
+        long bytesY = (long) rows * Float.BYTES;
+
+        Fp32Scratch scratch = FP32_SCRATCH.get();
+
+        try (Arena callArena = Arena.ofConfined()) {
+            synchronized (ctx.cublasSerializationLock()) {
+                MemorySegment stream = ensureStream();
+                bindStream(stream);
+                try {
+                    ensureFp32Scratch(scratch, bytesX, bytesY);
+
+                    // H2D of x — stage heap→native first (Java 25 forbids heap segments in downcalls).
+                    MemorySegment stagingX = callArena.allocate(bytesX);
+                    stagingX.copyFrom(MemorySegment.ofArray(x));
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaMemcpyAsync(),
+                            scratch.dX, stagingX, bytesX, GpuBindings.H2D, stream),
+                        "hipMemcpyAsync(x H2D)");
+
+                    callSgemvFp32(A.devicePointer(), cols, scratch.dX, scratch.dY, rows, cols);
+
+                    MemorySegment stagingY = callArena.allocate(bytesY);
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaMemcpyAsync(),
+                            stagingY, scratch.dY, bytesY, GpuBindings.D2H, stream),
+                        "hipMemcpyAsync(y D2H)");
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaStreamSynchronize(), stream),
+                        "hipStreamSynchronize");
+
+                    float[] y = new float[rows];
+                    MemorySegment.copy(stagingY, JAVA_FLOAT, 0, y, 0, rows);
+                    return y;
+                } finally {
+                    unbindStream();
+                }
+            }
+        } finally {
+            evt.backend = "rocm-resident";
+            evt.rows = rows;
+            evt.cols = cols;
+            evt.commit();
+        }
     }
 
     /**
-     * Device-resident FP16 path — not yet supported on ROCm.
+     * Device-resident FP16 path: A is FP16 on the device; x is FP32 on the host.
      *
-     * @throws UnsupportedOperationException always
+     * x is converted to FP16 in a confined off-heap arena and uploaded; the
+     * {@code rocblas_hssgemv_strided_batched} kernel (batch=1) accumulates in
+     * FP32. Mirrors {@link CudaMatVec#sgemv(DeviceHalfMatrix, float[])}.
      */
     @Override
     public float[] sgemv(DeviceHalfMatrix A, float[] x) {
-        throw new UnsupportedOperationException(
-            "RocmMatVec: device-resident FP16 path not yet supported. " +
-            "DeviceHalfMatrix uses CudaBindings internally. " +
-            "See GpuContext.createMatVec() javadoc for the host-weight workaround.");
+        if (A == null) throw new IllegalArgumentException("A must not be null");
+        if (A.isClosed()) throw new IllegalStateException("DeviceHalfMatrix is closed");
+        int rows = A.rows(), cols = A.cols();
+        if (x.length != cols)
+            throw new IllegalArgumentException("x.length=" + x.length + " != cols=" + cols);
+
+        MatVecEvent evt = new MatVecEvent();
+        evt.begin();
+
+        long bytesXh = (long) cols * Short.BYTES;  // FP16
+        long bytesY  = (long) rows * Float.BYTES;  // FP32
+
+        Fp16Scratch scratch = FP16_SCRATCH.get();
+
+        try (Arena callArena = Arena.ofConfined()) {
+            synchronized (ctx.cublasSerializationLock()) {
+                MemorySegment stream = ensureStream();
+                bindStream(stream);
+                try {
+                    ensureFp16Scratch(scratch, bytesXh, bytesY);
+
+                    // Pack x as FP16 into off-heap staging. JAVA_SHORT has native byte order
+                    // (little-endian on x86), matching HIP's __half layout.
+                    MemorySegment stagingXh = callArena.allocate(bytesXh);
+                    for (int j = 0; j < cols; j++)
+                        stagingXh.setAtIndex(JAVA_SHORT, j, Float.floatToFloat16(x[j]));
+
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaMemcpyAsync(),
+                            scratch.dXh, stagingXh, bytesXh, GpuBindings.H2D, stream),
+                        "hipMemcpyAsync(xh H2D)");
+
+                    callSgemvFp16(A.devicePointer(), cols, scratch.dXh, scratch.dY, rows, cols);
+
+                    MemorySegment stagingY = callArena.allocate(bytesY);
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaMemcpyAsync(),
+                            stagingY, scratch.dY, bytesY, GpuBindings.D2H, stream),
+                        "hipMemcpyAsync(y D2H)");
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaStreamSynchronize(), stream),
+                        "hipStreamSynchronize");
+
+                    float[] y = new float[rows];
+                    MemorySegment.copy(stagingY, JAVA_FLOAT, 0, y, 0, rows);
+                    return y;
+                } finally {
+                    unbindStream();
+                }
+            }
+        } finally {
+            evt.backend = "rocm-resident-fp16";
+            evt.rows = rows;
+            evt.cols = cols;
+            evt.commit();
+        }
     }
 
     // ── rocBLAS GEMV ──────────────────────────────────────────────────────────
@@ -219,6 +345,37 @@ public final class RocmMatVec implements MatVec {
                     dX, 1,
                     beta, dY, 1),
                 "rocblas_sgemv");
+        }
+    }
+
+    /**
+     * rocblas_hssgemv_strided_batched: y(FP32) = A(FP16) * x(FP16), batch=1.
+     *
+     * <p>Same (trans, m, n, lda) mapping as {@link #callSgemvFp32}; alpha/beta
+     * are FP32 (host pointer mode). This is the rocBLAS analogue of cuBLAS's
+     * {@code cublasHSSgemvStridedBatched}.
+     */
+    private void callSgemvFp16(MemorySegment dA, int lda,
+                                MemorySegment dXh, MemorySegment dY,
+                                int rows, int cols) {
+        long strideA = (long) cols * rows;
+        long strideX = cols;
+        long strideY = rows;
+        try (Arena scalars = Arena.ofConfined()) {
+            MemorySegment alpha = scalars.allocateFrom(JAVA_FLOAT, 1.0f);
+            MemorySegment beta  = scalars.allocateFrom(JAVA_FLOAT, 0.0f);
+            GpuBindings.check(
+                GpuBindings.callInt(rocm.cublasSetPointerMode(), ctx.handle(), rocm.pointerModeHost()),
+                "rocblas_set_pointer_mode");
+            GpuBindings.check(
+                GpuBindings.callInt(rocm.cublasHSSgemvStridedBatched(),
+                    ctx.handle(), rocm.opTranspose(),
+                    cols, rows,
+                    alpha, dA, lda, strideA,
+                    dXh, 1, strideX,
+                    beta, dY, 1, strideY,
+                    1),
+                "rocblas_hssgemv_strided_batched");
         }
     }
 
@@ -255,12 +412,26 @@ public final class RocmMatVec implements MatVec {
 
     // ── Scratch growth ────────────────────────────────────────────────────────
 
-    private void ensureScratch(Scratch s, long bytesX, long bytesY) {
+    private void ensureFp32Scratch(Fp32Scratch s, long bytesX, long bytesY) {
         int dev = ctx.deviceIndex();
         if (s.dXBytes < bytesX) {
             rocm.deviceFree(s.dX);
             s.dX     = rocm.deviceMalloc(dev, bytesX);
             s.dXBytes = bytesX;
+        }
+        if (s.dYBytes < bytesY) {
+            rocm.deviceFree(s.dY);
+            s.dY     = rocm.deviceMalloc(dev, bytesY);
+            s.dYBytes = bytesY;
+        }
+    }
+
+    private void ensureFp16Scratch(Fp16Scratch s, long bytesXh, long bytesY) {
+        int dev = ctx.deviceIndex();
+        if (s.dXhBytes < bytesXh) {
+            rocm.deviceFree(s.dXh);
+            s.dXh     = rocm.deviceMalloc(dev, bytesXh);
+            s.dXhBytes = bytesXh;
         }
         if (s.dYBytes < bytesY) {
             rocm.deviceFree(s.dY);

--- a/node/src/main/java/cab/ml/juno/node/RocmMatVec.java
+++ b/node/src/main/java/cab/ml/juno/node/RocmMatVec.java
@@ -123,23 +123,35 @@ public final class RocmMatVec implements MatVec {
         MemorySegment dX = rocm.deviceMalloc(ctx.deviceIndex(), bytesX);
         MemorySegment dY = rocm.deviceMalloc(ctx.deviceIndex(), bytesY);
         try {
-            // H2D — synchronous hipMemcpy; Panama pins the heap arrays during the call.
-            GpuBindings.check(
-                GpuBindings.callInt(rocm.cudaMemcpy(), dA, MemorySegment.ofArray(A), bytesA, GpuBindings.H2D),
-                "hipMemcpy(A H2D)");
-            GpuBindings.check(
-                GpuBindings.callInt(rocm.cudaMemcpy(), dX, MemorySegment.ofArray(x), bytesX, GpuBindings.H2D),
-                "hipMemcpy(x H2D)");
-
-            float[] y = new float[rows];
-            synchronized (ctx.cublasSerializationLock()) {
-                callSgemvFp32(dA, cols, dX, dY, rows, cols);
-                // Synchronous D2H: heap array is safe here (hipMemcpy blocks until done).
+            // H2D — copy Java heap arrays into native (off-heap) staging buffers first;
+            // Panama FFI (Java 25) forbids passing heap-backed MemorySegments directly
+            // to native downcalls ("Heap segment not allowed").
+            try (Arena hostArena = Arena.ofConfined()) {
+                MemorySegment nativeA = hostArena.allocate(bytesA);
+                MemorySegment nativeX = hostArena.allocate(bytesX);
+                nativeA.copyFrom(MemorySegment.ofArray(A)); // heap→native (Java copy, no FFI)
+                nativeX.copyFrom(MemorySegment.ofArray(x));
                 GpuBindings.check(
-                    GpuBindings.callInt(rocm.cudaMemcpy(), MemorySegment.ofArray(y), dY, bytesY, GpuBindings.D2H),
-                    "hipMemcpy(y D2H)");
+                    GpuBindings.callInt(rocm.cudaMemcpy(), dA, nativeA, bytesA, GpuBindings.H2D),
+                    "hipMemcpy(A H2D)");
+                GpuBindings.check(
+                    GpuBindings.callInt(rocm.cudaMemcpy(), dX, nativeX, bytesX, GpuBindings.H2D),
+                    "hipMemcpy(x H2D)");
             }
-            return y;
+
+            // D2H — similarly, copy into native staging first, then into Java array.
+            try (Arena resultArena = Arena.ofConfined()) {
+                MemorySegment stagingY = resultArena.allocate(bytesY);
+                synchronized (ctx.cublasSerializationLock()) {
+                    callSgemvFp32(dA, cols, dX, dY, rows, cols);
+                    GpuBindings.check(
+                        GpuBindings.callInt(rocm.cudaMemcpy(), stagingY, dY, bytesY, GpuBindings.D2H),
+                        "hipMemcpy(y D2H)");
+                }
+                float[] y = new float[rows];
+                MemorySegment.copy(stagingY, JAVA_FLOAT, 0, y, 0, rows);
+                return y;
+            }
         } finally {
             rocm.deviceFree(dA);
             rocm.deviceFree(dX);

--- a/node/src/test/java/cab/ml/juno/node/ForwardPassHandlerLoaderSelectBackendTest.java
+++ b/node/src/test/java/cab/ml/juno/node/ForwardPassHandlerLoaderSelectBackendTest.java
@@ -66,6 +66,7 @@ class ForwardPassHandlerLoaderSelectBackendTest {
     @DisplayName("JUNO_USE_GPU=true on CPU-only machine → falls back to CpuMatVec")
     void gpu_flag_true_no_cuda_falls_back_to_cpu() {
         assumeFalse(CudaAvailability.isAvailable(), "Skipping — CUDA present on this machine");
+        assumeFalse(RocmAvailability.isAvailable(), "Skipping — ROCm present on this machine");
         System.setProperty("JUNO_USE_GPU", "true");
 
         MatVec backend = ForwardPassHandlerLoader.selectBackend();
@@ -111,5 +112,37 @@ class ForwardPassHandlerLoaderSelectBackendTest {
         assertThat(b).isInstanceOf(CudaMatVec.class);
         assertThat(((CudaMatVec) a).gpuContext()).isSameAs(((CudaMatVec) b).gpuContext());
         assertThat(((CudaMatVec) a).gpuContext().isProcessShared()).isTrue();
+    }
+
+    // ── ROCm-tagged (runs only on AMD ROCm nodes) ─────────────────────────────
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("JUNO_USE_GPU=true on ROCm-only node → RocmMatVec")
+    void gpu_flag_true_with_rocm_yields_rocm_backend() {
+        assumeTrue(RocmAvailability.isAvailable(), "No ROCm device — skipping");
+        assumeFalse(CudaAvailability.isAvailable(), "CUDA also present — CUDA wins, skipping ROCm check");
+        System.setProperty("JUNO_USE_GPU", "true");
+
+        MatVec backend = ForwardPassHandlerLoader.selectBackend();
+
+        assertThat(backend).isInstanceOf(RocmMatVec.class);
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("selectBackend() on ROCm node reuses process-wide GpuContext.shared(0)")
+    void select_backend_reuses_shared_gpu_context_on_rocm() {
+        assumeTrue(RocmAvailability.isAvailable(), "No ROCm device — skipping");
+        assumeFalse(CudaAvailability.isAvailable(), "CUDA also present — CUDA wins, skipping ROCm check");
+        System.setProperty("JUNO_USE_GPU", "true");
+
+        MatVec a = ForwardPassHandlerLoader.selectBackend();
+        MatVec b = ForwardPassHandlerLoader.selectBackend();
+
+        assertThat(a).isInstanceOf(RocmMatVec.class);
+        assertThat(b).isInstanceOf(RocmMatVec.class);
+        assertThat(((RocmMatVec) a).gpuContext()).isSameAs(((RocmMatVec) b).gpuContext());
+        assertThat(((RocmMatVec) a).gpuContext().isProcessShared()).isTrue();
     }
 }

--- a/node/src/test/java/cab/ml/juno/node/ForwardPassHandlerLoaderSelectLoraBackendTest.java
+++ b/node/src/test/java/cab/ml/juno/node/ForwardPassHandlerLoaderSelectLoraBackendTest.java
@@ -41,9 +41,10 @@ class ForwardPassHandlerLoaderSelectLoraBackendTest {
 	}
 
 	@Test
-	@DisplayName("JUNO_USE_GPU absent and no CUDA → CpuMatVec")
+	@DisplayName("JUNO_USE_GPU absent and no GPU → CpuMatVec")
 	void absent_no_cuda_cpu() {
 		assumeFalse(CudaAvailability.isAvailable(), "CUDA present — skipping");
+		assumeFalse(RocmAvailability.isAvailable(), "ROCm present — skipping");
 		System.clearProperty("JUNO_USE_GPU");
 		assertThat(ForwardPassHandlerLoader.selectLoraBackend()).isInstanceOf(CpuMatVec.class);
 	}
@@ -55,5 +56,15 @@ class ForwardPassHandlerLoaderSelectLoraBackendTest {
 		assumeTrue(CudaAvailability.isAvailable(), "No CUDA — skipping");
 		System.clearProperty("JUNO_USE_GPU");
 		assertThat(ForwardPassHandlerLoader.selectLoraBackend()).isInstanceOf(CudaMatVec.class);
+	}
+
+	@Test
+	@Tag("rocm")
+	@DisplayName("JUNO_USE_GPU absent and ROCm available → RocmMatVec")
+	void absent_rocm_gpu() {
+		assumeTrue(RocmAvailability.isAvailable(), "No ROCm — skipping");
+		assumeFalse(CudaAvailability.isAvailable(), "CUDA present — CUDA wins, skipping ROCm check");
+		System.clearProperty("JUNO_USE_GPU");
+		assertThat(ForwardPassHandlerLoader.selectLoraBackend()).isInstanceOf(RocmMatVec.class);
 	}
 }

--- a/node/src/test/java/cab/ml/juno/node/GpuContextTest.java
+++ b/node/src/test/java/cab/ml/juno/node/GpuContextTest.java
@@ -121,4 +121,48 @@ class GpuContextTest {
 		GpuBindings bindings = GpuContext.selectBindings();
 		assertThat(bindings).isInstanceOf(CudaBindings.class);
 	}
+
+	@Test
+	@Tag("rocm")
+	@DisplayName("createMatVec() returns RocmMatVec on AMD-only system")
+	void create_mat_vec_returns_rocm_mat_vec_on_amd() {
+		assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+		assumeFalse(CudaAvailability.isAvailable(), "Skipping — CUDA present, CUDA wins");
+		try (GpuContext ctx = GpuContext.init(0)) {
+			MatVec mv = ctx.createMatVec();
+			assertThat(mv).isInstanceOf(RocmMatVec.class);
+		}
+	}
+
+	@Test
+	@Tag("rocm")
+	@DisplayName("shared(0) is a singleton on ROCm system; close() is a no-op")
+	void shared_singleton_close_is_noop_on_rocm() {
+		assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+		assumeFalse(CudaAvailability.isAvailable(), "Skipping — CUDA present, CUDA wins");
+		GpuContext a = GpuContext.shared(0);
+		GpuContext b = GpuContext.shared(0);
+		assertThat(a).isSameAs(b);
+		assertThat(a.isProcessShared()).isTrue();
+		a.close();                         // must not actually close
+		assertThat(a.isClosed()).isFalse();
+		assertThat(a.handle()).isNotNull();
+	}
+
+	@Test
+	@Tag("rocm")
+	@DisplayName("selectBindings() with juno.gpu.backend=rocm returns RocmBindings")
+	void select_bindings_forced_rocm_returns_rocm_bindings() {
+		assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+		String prev = System.getProperty("juno.gpu.backend");
+		try {
+			System.setProperty("juno.gpu.backend", "rocm");
+			GpuBindings bindings = GpuContext.selectBindings();
+			assertThat(bindings).isInstanceOf(RocmBindings.class);
+			assertThat(bindings.backendLabel()).isEqualTo("rocm");
+		} finally {
+			if (prev == null) System.clearProperty("juno.gpu.backend");
+			else System.setProperty("juno.gpu.backend", prev);
+		}
+	}
 }

--- a/node/src/test/java/cab/ml/juno/node/RocmAvailabilityTest.java
+++ b/node/src/test/java/cab/ml/juno/node/RocmAvailabilityTest.java
@@ -1,0 +1,140 @@
+package cab.ml.juno.node;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * RocmAvailability detection tests.
+ *
+ * <p>Two scenarios:
+ * <ol>
+ *   <li>ROCm present ({@code @Tag("rocm")}) — verifies device count, name, and VRAM.
+ *   <li>ROCm absent (CPU-only / CUDA-only) — verifies all methods return safe fallback values.
+ * </ol>
+ *
+ * <p>Run on ROCm machines:
+ * <pre>
+ *   mvn test -Dgroups=rocm -pl node
+ * </pre>
+ * Run on CPU-only / CUDA-only:
+ * <pre>
+ *   mvn test -Dgroups='!rocm' -pl node
+ * </pre>
+ */
+@DisplayName("RocmAvailability — HIP device detection")
+class RocmAvailabilityTest {
+
+    // ── ROCm absent path ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("isAvailable() returns false when ROCm libraries are absent")
+    void is_available_returns_false_when_no_rocm() {
+        assumeFalse(RocmAvailability.isAvailable(), "Skipping — ROCm is present on this machine");
+        assertThat(RocmAvailability.isAvailable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("deviceCount() returns 0 when ROCm is unavailable")
+    void device_count_returns_zero_when_unavailable() {
+        assumeFalse(RocmAvailability.isAvailable(), "Skipping — ROCm is present on this machine");
+        assertThat(RocmAvailability.deviceCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("deviceName(0) returns 'unavailable' when ROCm is absent")
+    void device_name_returns_unavailable_when_absent() {
+        assumeFalse(RocmAvailability.isAvailable(), "Skipping — ROCm is present on this machine");
+        assertThat(RocmAvailability.deviceName(0)).isEqualTo("unavailable");
+    }
+
+    @Test
+    @DisplayName("vramBytes(0) returns 0 when ROCm is unavailable")
+    void vram_bytes_returns_zero_when_unavailable() {
+        assumeFalse(RocmAvailability.isAvailable(), "Skipping — ROCm is present on this machine");
+        assertThat(RocmAvailability.vramBytes(0)).isEqualTo(0L);
+    }
+
+    // ── ROCm present path (@Tag("rocm")) ──────────────────────────────────────
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("isAvailable() returns true on ROCm system")
+    void is_available_returns_true_on_rocm_system() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        assertThat(RocmAvailability.isAvailable()).isTrue();
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("deviceCount() is at least 1 on ROCm system")
+    void device_count_is_at_least_one() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        assertThat(RocmAvailability.deviceCount()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("deviceName(0) is non-blank and does not equal 'unavailable'")
+    void device_name_is_non_blank() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        String name = RocmAvailability.deviceName(0);
+        assertThat(name)
+            .isNotBlank()
+            .isNotEqualTo("unavailable")
+            .isNotEqualTo("unknown");
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("deviceName(0) contains 'AMD', 'Radeon', or 'Instinct' (AMD GPU identifier)")
+    void device_name_identifies_amd_gpu() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        String name = RocmAvailability.deviceName(0).toUpperCase();
+        boolean isAmd = name.contains("AMD") || name.contains("RADEON") || name.contains("INSTINCT");
+        assertThat(isAmd)
+            .as("Expected an AMD GPU name but got: '%s'", RocmAvailability.deviceName(0))
+            .isTrue();
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("vramBytes(0) is positive")
+    void vram_bytes_is_positive() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        assertThat(RocmAvailability.vramBytes(0)).isGreaterThan(0L);
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("vramBytes(0) reports at least 1 GB (minimum usable AMD GPU for inference)")
+    void vram_bytes_at_least_1gb() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        long oneGb = 1_073_741_824L;
+        assertThat(RocmAvailability.vramBytes(0))
+            .as("VRAM should be at least 1 GB")
+            .isGreaterThanOrEqualTo(oneGb);
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("deviceName(-1) returns 'unknown' for out-of-range index")
+    void device_name_out_of_range_returns_fallback() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        // hipGetDevicePropertiesR0600 with index = 999 returns a non-zero rc
+        String name = RocmAvailability.deviceName(999);
+        assertThat(name).isIn("unknown", "unavailable");
+    }
+
+    @Test
+    @Tag("rocm")
+    @DisplayName("vramBytes(999) returns 0 for out-of-range index")
+    void vram_bytes_out_of_range_returns_zero() {
+        assumeTrue(RocmAvailability.isAvailable(), "Skipping — no ROCm device");
+        assertThat(RocmAvailability.vramBytes(999)).isEqualTo(0L);
+    }
+}

--- a/node/src/test/java/cab/ml/juno/node/RocmMatVecTest.java
+++ b/node/src/test/java/cab/ml/juno/node/RocmMatVecTest.java
@@ -126,22 +126,59 @@ class RocmMatVecTest extends MatVecBackendContractTest {
         assertThat(y[1]).isCloseTo(15.0f, within(1e-5f));
     }
 
-    // ── Unsupported device-resident paths ─────────────────────────────────────
+    // ── Device-resident paths (A held on the GPU across calls) ─────────────────
 
     @Test
-    @DisplayName("sgemv(DeviceFloatMatrix, x) throws UnsupportedOperationException")
-    void device_float_matrix_throws_unsupported() {
+    @DisplayName("sgemv(DeviceFloatMatrix, x) rejects a null matrix")
+    void device_float_matrix_rejects_null() {
         assertThatThrownBy(() -> rocmImpl.sgemv((DeviceFloatMatrix) null, new float[]{1f}))
-            .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("device-resident FP32 path not yet supported");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("A must not be null");
     }
 
     @Test
-    @DisplayName("sgemv(DeviceHalfMatrix, x) throws UnsupportedOperationException")
-    void device_half_matrix_throws_unsupported() {
+    @DisplayName("sgemv(DeviceHalfMatrix, x) rejects a null matrix")
+    void device_half_matrix_rejects_null() {
         assertThatThrownBy(() -> rocmImpl.sgemv((DeviceHalfMatrix) null, new float[]{1f}))
-            .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("device-resident FP16 path not yet supported");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("A must not be null");
+    }
+
+    @Test
+    @DisplayName("device-resident FP32 path matches CPU reference — 2048×2048")
+    void device_resident_fp32_matches_cpu_reference() {
+        int rows = 2048, cols = 2048;
+        float[] A = randomMatrix(rows, cols, 200);
+        float[] x = randomVector(cols, 201);
+
+        float[] cpuResult = LlamaTransformerHandler.matVec(A, x, rows, cols);
+        try (DeviceFloatMatrix dA = rocmImpl.upload(A, rows, cols)) {
+            float[] rocmResult = rocmImpl.sgemv(dA, x);
+            assertThat(rocmResult).hasSize(rows);
+            for (int i = 0; i < rows; i++)
+                assertThat(rocmResult[i])
+                    .as("y[%d]", i)
+                    .isCloseTo(cpuResult[i], within(DELTA));
+        }
+    }
+
+    @Test
+    @DisplayName("device-resident FP16 path matches CPU reference — 2048×2048 (FP16 tolerance)")
+    void device_resident_fp16_matches_cpu_reference() {
+        int rows = 2048, cols = 2048;
+        float[] A = randomMatrix(rows, cols, 210);
+        float[] x = randomVector(cols, 211);
+
+        float[] cpuResult = LlamaTransformerHandler.matVec(A, x, rows, cols);
+        try (DeviceHalfMatrix dA = rocmImpl.uploadHalf(A, rows, cols)) {
+            float[] rocmResult = rocmImpl.sgemv(dA, x);
+            assertThat(rocmResult).hasSize(rows);
+            // FP16 weights/activations: looser tolerance than the FP32 paths.
+            for (int i = 0; i < rows; i++)
+                assertThat(rocmResult[i])
+                    .as("y[%d]", i)
+                    .isCloseTo(cpuResult[i], within(1e-3f));
+        }
     }
 
     // ── Constructor validation ────────────────────────────────────────────────

--- a/node/src/test/java/cab/ml/juno/node/RocmMatVecTest.java
+++ b/node/src/test/java/cab/ml/juno/node/RocmMatVecTest.java
@@ -1,0 +1,223 @@
+package cab.ml.juno.node;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * RocmMatVec correctness and contract tests — requires an AMD GPU with ROCm 6+.
+ *
+ * <p>Inherits the full {@link MatVecBackendContractTest} suite so every contract
+ * that holds for {@link CpuMatVec} must also hold for {@link RocmMatVec}.
+ * Additionally tests ROCm-specific behaviour: correctness vs the CPU reference
+ * implementation, concurrent safety, and the unsupported device-resident paths.
+ *
+ * <p>Run on ROCm machines:
+ * <pre>
+ *   mvn test -Dgroups=rocm -pl node
+ * </pre>
+ * Skip on CPU-only / CUDA-only:
+ * <pre>
+ *   mvn test -Dgroups='!rocm' -pl node
+ * </pre>
+ */
+@Tag("rocm")
+@DisplayName("RocmMatVec — rocblas_sgemv correctness (requires AMD ROCm)")
+class RocmMatVecTest extends MatVecBackendContractTest {
+
+    private static GpuContext ctx;
+    private static RocmMatVec rocmImpl;
+
+    @BeforeAll
+    static void initRocm() {
+        assumeTrue(RocmAvailability.isAvailable(),
+            "Skipping RocmMatVecTest — no ROCm device available");
+        ctx = GpuContext.init(0);
+        rocmImpl = new RocmMatVec(ctx);
+    }
+
+    @AfterAll
+    static void destroyRocm() {
+        if (ctx != null) ctx.close();
+    }
+
+    /** Provide RocmMatVec to the inherited contract tests. */
+    @Override
+    protected MatVec impl() {
+        return rocmImpl;
+    }
+
+    // ── ROCm-specific correctness tests ───────────────────────────────────────
+
+    @Test
+    @DisplayName("rocblas_sgemv matches LlamaTransformerHandler.matVec — 2048×2048 hidden dim")
+    void rocblas_matches_cpu_reference_hidden_dim() {
+        int rows = 2048, cols = 2048;
+        float[] A = randomMatrix(rows, cols, 100);
+        float[] x = randomVector(cols, 101);
+
+        float[] cpuResult  = LlamaTransformerHandler.matVec(A, x, rows, cols);
+        float[] rocmResult = rocmImpl.sgemv(A, x, rows, cols);
+
+        assertThat(rocmResult).hasSize(rows);
+        for (int i = 0; i < rows; i++)
+            assertThat(rocmResult[i])
+                .as("y[%d]", i)
+                .isCloseTo(cpuResult[i], within(DELTA));
+    }
+
+    @Test
+    @DisplayName("rocblas_sgemv matches CPU reference — 5632×2048 FFN gate (TinyLlama)")
+    void rocblas_matches_cpu_reference_ffn_gate() {
+        int rows = 5632, cols = 2048;
+        float[] A = randomMatrix(rows, cols, 110);
+        float[] x = randomVector(cols, 111);
+
+        float[] cpuResult  = LlamaTransformerHandler.matVec(A, x, rows, cols);
+        float[] rocmResult = rocmImpl.sgemv(A, x, rows, cols);
+
+        assertThat(rocmResult).hasSize(rows);
+        for (int i = 0; i < rows; i++)
+            assertThat(rocmResult[i])
+                .as("y[%d]", i)
+                .isCloseTo(cpuResult[i], within(DELTA));
+    }
+
+    @Test
+    @DisplayName("rocblas_sgemv matches CPU reference — 32000×2048 output projection")
+    void rocblas_matches_cpu_reference_output_projection() {
+        int rows = 32000, cols = 2048;
+        float[] A = randomMatrix(rows, cols, 102);
+        float[] x = randomVector(cols, 103);
+
+        float[] cpuResult  = LlamaTransformerHandler.matVec(A, x, rows, cols);
+        float[] rocmResult = rocmImpl.sgemv(A, x, rows, cols);
+
+        for (int i = 0; i < rows; i++)
+            assertThat(rocmResult[i])
+                .as("y[%d]", i)
+                .isCloseTo(cpuResult[i], within(DELTA));
+    }
+
+    @Test
+    @DisplayName("1×1 trivial: A=[2.0], x=[3.0] → y=[6.0]")
+    void trivial_1x1_known_value() {
+        float[] y = rocmImpl.sgemv(new float[]{2.0f}, new float[]{3.0f}, 1, 1);
+        assertThat(y).hasSize(1);
+        assertThat(y[0]).isCloseTo(6.0f, within(1e-5f));
+    }
+
+    @Test
+    @DisplayName("2×3 known result: y = [1+2+3, 4+5+6] = [6, 15]")
+    void known_2x3_result() {
+        float[] A = {1, 2, 3,  4, 5, 6};
+        float[] x = {1, 1, 1};
+        float[] y = rocmImpl.sgemv(A, x, 2, 3);
+        assertThat(y).hasSize(2);
+        assertThat(y[0]).isCloseTo(6.0f, within(1e-5f));
+        assertThat(y[1]).isCloseTo(15.0f, within(1e-5f));
+    }
+
+    // ── Unsupported device-resident paths ─────────────────────────────────────
+
+    @Test
+    @DisplayName("sgemv(DeviceFloatMatrix, x) throws UnsupportedOperationException")
+    void device_float_matrix_throws_unsupported() {
+        assertThatThrownBy(() -> rocmImpl.sgemv((DeviceFloatMatrix) null, new float[]{1f}))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("device-resident FP32 path not yet supported");
+    }
+
+    @Test
+    @DisplayName("sgemv(DeviceHalfMatrix, x) throws UnsupportedOperationException")
+    void device_half_matrix_throws_unsupported() {
+        assertThatThrownBy(() -> rocmImpl.sgemv((DeviceHalfMatrix) null, new float[]{1f}))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("device-resident FP16 path not yet supported");
+    }
+
+    // ── Constructor validation ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("RocmMatVec(null) throws IllegalArgumentException")
+    void constructor_rejects_null_context() {
+        assertThatThrownBy(() -> new RocmMatVec(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("ctx must not be null");
+    }
+
+    // ── Backend identity ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GpuContext.backendLabel() is 'rocm' on AMD system")
+    void gpu_context_backend_label_is_rocm() {
+        assumeFalse(CudaAvailability.isAvailable(), "Skipping — CUDA present, CUDA wins");
+        assertThat(ctx.backendLabel()).isEqualTo("rocm");
+    }
+
+    @Test
+    @DisplayName("GpuContext.createMatVec() returns RocmMatVec on AMD system")
+    void create_mat_vec_returns_rocm_mat_vec() {
+        assumeFalse(CudaAvailability.isAvailable(), "Skipping — CUDA present, CUDA wins");
+        MatVec mv = ctx.createMatVec();
+        assertThat(mv).isInstanceOf(RocmMatVec.class);
+    }
+
+    // ── Concurrent safety ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Concurrent sgemv calls produce correct results (4 threads × 256×256)")
+    void concurrent_calls_are_correct() throws InterruptedException {
+        int rows = 256, cols = 256;
+        int threads = 4;
+        float[] A = randomMatrix(rows, cols, 300);
+        float[] x = randomVector(cols, 301);
+        float[] expected = scalarMatVec(A, x, rows, cols);
+
+        Thread[] workers = new Thread[threads];
+        float[][] results = new float[threads][];
+        for (int t = 0; t < threads; t++) {
+            final int idx = t;
+            workers[t] = new Thread(() ->
+                results[idx] = rocmImpl.sgemv(A, x, rows, cols));
+            workers[t].start();
+        }
+        for (Thread w : workers) w.join();
+
+        for (int t = 0; t < threads; t++) {
+            for (int i = 0; i < rows; i++)
+                assertThat(results[t][i])
+                    .as("thread=%d y[%d]", t, i)
+                    .isCloseTo(expected[i], within(DELTA));
+        }
+    }
+
+    // ── Throughput sanity ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("ROCm path has reasonable latency for 32000×2048 output projection (< 3 s for 5 runs)")
+    void rocm_path_has_reasonable_latency() {
+        int rows = 32000, cols = 2048;
+        float[] A = randomMatrix(rows, cols, 200);
+        float[] x = randomVector(cols, 201);
+
+        // warm up
+        rocmImpl.sgemv(A, x, rows, cols);
+        rocmImpl.sgemv(A, x, rows, cols);
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 5; i++) rocmImpl.sgemv(A, x, rows, cols);
+        long ms = (System.nanoTime() - start) / 1_000_000;
+
+        System.out.printf("32000×2048 rocblas_sgemv — %dms (5 runs)%n", ms);
+        assertThat(ms).isLessThan(3_000L);
+    }
+}


### PR DESCRIPTION
## Summary

Add first-class AMD GPU support to jUno inference nodes via the ROCm/HIP runtime, making the GPU acceleration layer vendor-neutral: it now auto-selects **CUDA → ROCm → CPU** at startup with no configuration required.

## Context

jUno performs distributed LLM inference by splitting transformer weight matrices across nodes and running `matVec` (matrix-vector multiply) on each shard. Previously, GPU acceleration was hard-coded to NVIDIA CUDA (`libcudart.so.12` + `libcublas.so.12`), meaning our development machine — an **AMD Radeon RX 7900 XT (21.5 GB VRAM, RDNA 3 / gfx1100, ROCm 7.2.53211)** — could not exercise any GPU code path. All `@Tag("gpu")` tests were permanently skipped locally.

This PR introduces a parallel ROCm backend using `libamdhip64.so` + `librocblas.so` through Java 25 Panama FFI — zero native `.so` shim required — and validates it on the real card.

A key bug was also fixed during validation: Panama FFI in Java 25 rejects heap-backed `MemorySegment` in native downcalls (`"Heap segment not allowed"`). The initial ROCm implementation passed `MemorySegment.ofArray(float[])` directly into `rocblas_sgemv`. Fix: all host arrays are now staged through `Arena.ofConfined()` before the downcall — matching the pattern already used in `CudaBindings`.

## Changes

### New production files

| File | Purpose |
|---|---|
| `GpuBindings.java` | Vendor-neutral interface for both backends: handle accessors, `deviceMalloc`/`deviceFree`, `backendLabel()`, `createMatVec()`, shared static utilities (`check`, `callInt`, `loadLibrary`, `bind`) |
| `RocmBindings.java` | Panama FFI downcalls into `libamdhip64.so` (HIP runtime) and `librocblas.so` (rocBLAS) |
| `RocmAvailability.java` | HIP device detection: `isAvailable()`, `deviceCount()`, `deviceName(n)`, `vramBytes(n)` |
| `RocmMatVec.java` | `MatVec` implementation backed by `rocblas_sgemv`; host arrays staged via `Arena.ofConfined()` |

### Modified production files

| File | What changed |
|---|---|
| `GpuContext.java` | Refactored from CUDA-only to backend-agnostic: `selectBindings()` checks `juno.gpu.backend` system property → CUDA → ROCm → throws. Adds `backendLabel()`, `createMatVec()`, `bindings()`. |
| `ForwardPassHandlerLoader.java` | `selectBackend()` now routes `JUNO_USE_GPU=true` to `RocmMatVec` on AMD-only nodes |
| `CudaBindings.java` | Gains `implements GpuBindings` and the corresponding `@Override` accessor methods. **No existing fields or constants removed.** |
| `CudaAvailability.java` | Javadoc **expanded**: original `{@link CudaBindings#PROP_NAME_OFFSET}` and `{@link CudaBindings#PROP_TOTAL_MEM_OFFSET}` references preserved; new line added referencing `GpuBindings#propNameOffset()` / `propTotalMemOffset()` for vendor-neutral callers |
| `EmbeddedNodeServer.java` | Propagated `GpuContext` API change |
| `ConsoleMain.java`, `JunoPlayer.java` | Propagated `GpuContext` API change |

### New test files

| File | Tests | Coverage |
|---|---|---|
| `RocmMatVecTest.java` | **30** | Extends `MatVecBackendContractTest` (full contract parity with `CpuMatVec`); correctness vs CPU reference at three real model dimensions (2048×2048 hidden, 5632×2048 FFN gate, 32000×2048 output projection); trivial 1×1 and 2×3 known-value cases; `UnsupportedOperationException` on device-resident paths; `null` context rejection; backend label and factory method; concurrent safety (4 threads × 256×256); throughput sanity (< 3 s for 5 × 32000×2048 runs) |
| `RocmAvailabilityTest.java` | **8** | Device detection when ROCm present and absent; device count; name format (non-blank, contains "AMD"/"Radeon"/"Instinct"); VRAM ≥ 1 GB; out-of-range index fallbacks |

### Extended existing tests

| File | Added | Coverage |
|---|---|---|
| `GpuContextTest.java` | +5 `@Tag("rocm")` | `init(0)` returns open ROCm context; `selectBindings()` CUDA-over-ROCm priority; `createMatVec()` returns `RocmMatVec`; `shared(0)` singleton — `close()` is a no-op; `juno.gpu.backend=rocm` system-property override returns `RocmBindings` |
| `ForwardPassHandlerLoaderSelectBackendTest.java` | +2 `@Tag("rocm")` | `JUNO_USE_GPU=true` → `RocmMatVec` on AMD-only node; process-wide `GpuContext.shared(0)` reused across calls |
| `ForwardPassHandlerLoaderSelectLoraBackendTest.java` | +1 `@Tag("rocm")` | LoRA-enabled forward-pass routing selects ROCm backend on AMD node |
| `CudaBindingsTest.java` | Restored | `@Tag("gpu")` and original `assertThat(CudaBindings.DEVICE_PROP_BYTES)` assertion reinstated after they were incorrectly removed in a previous draft |

## Testing

### Run AMD GPU tests (requires ROCm device)

```bash
mvn test -pl node -Dgroups=rocm
```

Expected output on AMD RX 7900 XT:

```
ForwardPassHandlerLoaderSelectBackendTest   Tests run: 2,  Failures: 0, Errors: 0, Skipped: 0
ForwardPassHandlerLoaderSelectLoraBackendTest Tests run: 1,  Failures: 0, Errors: 0, Skipped: 0
GpuContextTest                              Tests run: 5,  Failures: 0, Errors: 0, Skipped: 1 *
RocmAvailabilityTest                        Tests run: 8,  Failures: 0, Errors: 0, Skipped: 0
RocmBindingsTest                            Tests run: 9,  Failures: 0, Errors: 0, Skipped: 0
RocmMatVecTest                              Tests run: 30, Failures: 0, Errors: 0, Skipped: 0

Tests run: 55, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS  (10.3 s)
```

\* 1 skipped = `select_bindings_cuda_priority` — requires both CUDA and ROCm simultaneously; expected on AMD-only hardware.

### Run CUDA GPU tests (requires NVIDIA device)

```bash
mvn test -pl node -Dgroups=gpu
```

### Run CPU-only tests (no GPU required)

```bash
mvn test -pl node -Dgroups='!rocm,!gpu'
```

### Run full build

```bash
mvn clean package
```

### Force a specific backend via system property

```bash
# Force ROCm even when CUDA is also present
-Djuno.gpu.backend=rocm

# Enable GPU inference at runtime
-DJUNO_USE_GPU=true
```

### Benchmark result on AMD Radeon RX 7900 XT

```
GpuContext ready — [rocm] device 0: AMD Radeon RX 7900 XT, 21.5 GB VRAM
32000×2048 rocblas_sgemv — 408 ms (5 runs)   threshold: 3 000 ms ✓
```

## Use Cases

- **Local development** on AMD hardware: all `@Tag("rocm")` tests now run locally; no NVIDIA card required to validate the GPU path
- **AMD GPU inference nodes** in a jUno cluster: set `JUNO_USE_GPU=true`, the node auto-detects ROCm and routes through `RocmMatVec` — same flag as CUDA nodes
- **Mixed clusters**: NVIDIA nodes use `CudaMatVec`, AMD nodes use `RocmMatVec`, CPU-only nodes use `CpuMatVec` — all behind the same `MatVec` interface, no cluster-level configuration needed
- **Forced backend override**: `juno.gpu.backend=rocm` system property selects ROCm explicitly, useful for testing on machines with both CUDA and ROCm installed
